### PR TITLE
Fix [AllowServer] attribute on subcommands

### DIFF
--- a/EasyCommandsTShock/EasyCommandsTShock/TShockCommandHandler.cs
+++ b/EasyCommandsTShock/EasyCommandsTShock/TShockCommandHandler.cs
@@ -25,13 +25,13 @@ namespace EasyCommandsTShock
 
         public override void PreCheck(TSPlayer sender, CommandDelegate<TSPlayer> command)
         {
-            CommandPermissions permissions = command.GetCustomAttribute<CommandPermissions>();
-
             // Stop the server from running a command if he's not allowed to, it's allowed by default
             if (command.GetCustomAttribute<AllowServer>()?.Allow == false)
             {
                 Fail("The server doesn't have the permission to execute this command.");
             }
+
+            CommandPermissions permissions = command.GetCustomAttribute<CommandPermissions>();
 
             // Stop a user from running a command or subcommand if they don't have permission to use it
             if(permissions != null && permissions.Permissions.Any(p => !sender.HasPermission(p)))

--- a/EasyCommandsTShock/EasyCommandsTShock/TShockCommandHandler.cs
+++ b/EasyCommandsTShock/EasyCommandsTShock/TShockCommandHandler.cs
@@ -27,6 +27,12 @@ namespace EasyCommandsTShock
         {
             CommandPermissions permissions = command.GetCustomAttribute<CommandPermissions>();
 
+            // Stop the server from running a command if he's not allowed to, it's allowed by default
+            if (command.GetCustomAttribute<AllowServer>()?.Allow == false)
+            {
+                Fail("The server doesn't have the permission to execute this command.");
+            }
+
             // Stop a user from running a command or subcommand if they don't have permission to use it
             if(permissions != null && permissions.Permissions.Any(p => !sender.HasPermission(p)))
             {

--- a/EasyCommandsTShock/EasyCommandsTShock/TShockCommandHandler.cs
+++ b/EasyCommandsTShock/EasyCommandsTShock/TShockCommandHandler.cs
@@ -26,7 +26,7 @@ namespace EasyCommandsTShock
         public override void PreCheck(TSPlayer sender, CommandDelegate<TSPlayer> command)
         {
             // Stop the server from running a command if he's not allowed to, it's allowed by default
-            if (command.GetCustomAttribute<AllowServer>()?.Allow == false)
+            if (sender is TSServerPlayer && command.GetCustomAttribute<AllowServer>()?.Allow == false)
             {
                 Fail("The server doesn't have the permission to execute this command.");
             }


### PR DESCRIPTION
As the commit description says, the attribute was working well on ***commands*** as **TShockApi** handled it well, but ***subcommands*** are not registered to **TShockApi** so it can't know whether the server is allowed to execute it or not.
It now works with ***commands*** and ***subcommands***.