### PR TITLE
fix: commands without a CommandPermissions attribute defaults to highest permission.

### DIFF
--- a/EasyCommandsTShock/EasyCommandsTShock/TShockCommandRepository.cs
+++ b/EasyCommandsTShock/EasyCommandsTShock/TShockCommandRepository.cs
@@ -51,7 +51,7 @@ namespace EasyCommandsTShock
             var allowServer = command.GetCustomAttribute<AllowServer>();
             var doLog = command.GetCustomAttribute<DoLog>();
 
-            var tshockCommand = new TShockAPI.Command(permissions != null ? permissions.Permissions.ToList() : new List<string>(), commandDelegate, names)
+            var tshockCommand = new TShockAPI.Command(permissions != null ? permissions.Permissions.ToList() : new List<string>() { "tshock."}, commandDelegate, names)
             {
                 HelpText = $"{(helpText != null ? helpText.Documentation : "")} Syntax: {command.SyntaxDocumentation(TSPlayer.Server)}",
                 AllowServer = allowServer != null ? allowServer.Allow : true,


### PR DESCRIPTION
This changes makes it so, if one forgets to add permissions to a command (that could be sensitive), only admins can use it. This helps against releasing a command into the wild by mistake.